### PR TITLE
🚨 [Fix] 깃허브 소셜 로그인 API 구현 - 로그인시에도 레포지토리가 불러와지는 문제 해결

### DIFF
--- a/src/main/java/com/server/pnd/oauth/controller/SignController.java
+++ b/src/main/java/com/server/pnd/oauth/controller/SignController.java
@@ -57,6 +57,11 @@ public class SignController {
         ResponseEntity<CustomApiResponse<?>> loginResponse = githubSocialLoginService.login(userInfo);
 
         // 5. 레포지토리 정보 가져오기
+        if (loginResponse.getStatusCode().isSameCodeAs(HttpStatus.OK)) {
+            // 로그인 한 경우 바로 리턴
+            return ResponseEntity.status(loginResponse.getStatusCode()).body(loginResponse.getBody());
+        }
+        // 회원가입 한 경우 레포지토리 정보 가져오기
         ResponseEntity<CustomApiResponse<?>> userRepositoryResponses = githubSocialLoginService.getUserRepository(tokenDto, userInfo);
         if (userInfoResponse.getStatusCode() != HttpStatus.OK) {
             return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());


### PR DESCRIPTION
### 🌈 Issue 번호
- close #104 

### 📄 변경 사항
로그인시에도 레포지토리가 불러와지는 문제 해결

### 🏆 테스트 결과
- 같은 계정으로 여러번 로그인 해도 DB에는 한 번만 불러와짐
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/b2c3bd93-c5bc-4724-ae08-82bee2369af2">

-> 추후에 레포 갱신 API 만들 예정. 우선은 해당 user의 모든 레포를 지우고 다시 불러오는 식으로 구현 예정. 추후 리펙토링을 한다면 각 각의 레포를 구별할 key 필요. (아마 user githubId와 깃허브 자체에서 제공해주는 레포지토리 id 복합키를 사용하면 될듯)


### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
