### PR TITLE
🚑️ Cors 정책 관련 오류 WebConfig 추가

### DIFF
--- a/src/main/java/com/server/pnd/util/config/WebConfig.java
+++ b/src/main/java/com/server/pnd/util/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.server.pnd.util.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:3000";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(DEVELOP_FRONT_ADDRESS)
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .exposedHeaders("location")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
CORS 정책 관련 오류 발생으로 인해 localhost:3000 -> localhost:8080으로 API 요청 불가능.
백엔드에서는 자신의 출처(8080포트)에서가 아닌 다른 오리진(3000포트)을 허용하지 않기 때문에 위와 같은 에러가 발생한 것이다. 

1. 백엔드 코드에서 Config>WebConfig 파일 추가

참고 블로그: https://khdscor.tistory.com/64

### 🌈 Issue 번호
- close #

### 📄 변경 사항
Config>WebConfig 파일 추가

### 🏆 테스트 결과

### Reviewer 요구 사항
